### PR TITLE
Fix "Undefined variable: dns" when AS lookup fails.

### DIFF
--- a/upload/library/TPUDetectSpamReg/AS.php
+++ b/upload/library/TPUDetectSpamReg/AS.php
@@ -37,7 +37,7 @@ class TPUDetectSpamReg_AS
 				$dns=dns_get_record(self::reverseIP($ip).'.origin.asn.cymru.com', DNS_TXT);
 		} catch(Exception $e) {}
 			
-		if ((is_array($dns)) && (isset($dns[0])))
+		if (isset($dns[0]))
 		{
 			$items=explode('|', $dns[0]['txt'], 2);
 			$items=array_shift($items);

--- a/upload/library/TPUDetectSpamReg/AS.php
+++ b/upload/library/TPUDetectSpamReg/AS.php
@@ -37,7 +37,7 @@ class TPUDetectSpamReg_AS
 				$dns=dns_get_record(self::reverseIP($ip).'.origin.asn.cymru.com', DNS_TXT);
 		} catch(Exception $e) {}
 			
-		if (isset($dns[0]))
+		if (isset($dns[0]['txt']))
 		{
 			$items=explode('|', $dns[0]['txt'], 2);
 			$items=array_shift($items);
@@ -45,7 +45,7 @@ class TPUDetectSpamReg_AS
 			if ($asNumber>0)
 			{
 				$dns=dns_get_record('AS'.$asNumber.'.asn.cymru.com', DNS_TXT);
-				if ((is_array($dns)) && (isset($dns[0])))
+				if (isset($dns[0]['txt']))
 				{
 					$tokens=explode('|', $dns[0]['txt']);
 					$asName=trim($tokens[4]);


### PR DESCRIPTION
Fixes the following error, caused when the AS lookup fails for some reason.

```
ErrorException: Undefined variable: dns - library/TPUDetectSpamReg/AS.php:40 
Generated By: Unknown Account, Today at 2:08 PM
#0 /var/www/html/library/TPUDetectSpamReg/AS.php(40): XenForo_Application::handlePhpError(8, 'Undefined varia...', '/var/www/sites/...', 40, Array)
#1 /var/www/html/library/TPUDetectSpamReg/AS.php(79): TPUDetectSpamReg_AS::getASNameAndNumber('129.72.154.121', NULL, NULL)
#2 [internal function]: TPUDetectSpamReg_AS::getRegSpamScore(Array, Array, '1', '0', Object(TPUDetectSpamReg_ModelSpamPrevention))
#3 /var/www/html/library/XenForo/CodeEvent.php(90): call_user_func_array(Array, Array)
#4 /var/www/html/library/TPUDetectSpamReg/ModelSpamPrevention.php(67): XenForo_CodeEvent::fire('tpu_detect_spam...', Array)
#5 /var/www/html/library/XenForo/ControllerPublic/Register.php(1426): TPUDetectSpamReg_ModelSpamPrevention->allowRegistration(Array, Object(Zend_Controller_Request_Http))
#6 /var/www/html/library/XenForo/ControllerPublic/Register.php(401): XenForo_ControllerPublic_Register->_runSpamCheck(Object(KL_PasswordTools_DataWriter_User), Array)
#7 /var/www/html/library/XenForo/FrontController.php(351): XenForo_ControllerPublic_Register->actionRegister()
#8 /var/www/html/library/XenForo/FrontController.php(134): XenForo_FrontController->dispatch(Object(XenForo_RouteMatch))
#9 /var/www/html/index.php(13): XenForo_FrontController->run()
#10 {main}
```
