### PR TITLE
Add .edu to default values

### DIFF
--- a/addon-TPUDetectSpamReg.xml
+++ b/addon-TPUDetectSpamReg.xml
@@ -220,6 +220,7 @@ Modify the value of $score to adjust scoring.]]></event>
 +1|*dedi*
 -1|*.gov
 -1|*.mil
+-1|*.edu
 +1|*.rdns.ubiquity.io
 +1|*.rdns.ubiquityservers.com
 +1|*.hostwindsdns.com


### PR DESCRIPTION
Add .edu to a -1 hostname

.edu is for college educational institutions and can be considered on the same trust level as a .gov domain
